### PR TITLE
Release v0.39.0-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+---
+
+## v0.39.0-beta - 2023-12-04
 ### Added
 - Core-API: feature flag settings.
+- Initial internal IR emitter for web-configurator development. Disabled by default with feature flag `internal_ir`.
 ### Changed
 - REST Core-API: enhance IrEmitterType enum with variant `INTERNAL`. This will be used for the internal IR blaster in the remote.
-
----
 
 ## v0.38.1-beta - 2023-12-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Core-API: feature flag settings.
+### Changed
+- REST Core-API: enhance IrEmitterType enum with variant `INTERNAL`. This will be used for the internal IR blaster in the remote.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Core-API: feature flag settings.
+
 ---
 
 ## v0.38.1-beta - 2023-12-01

--- a/core-api/rest/openapi.yaml
+++ b/core-api/rest/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Remote Two REST API
-  version: 0.29.0
+  version: 0.29.1
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
@@ -12233,9 +12233,15 @@ components:
         $ref: '#/components/schemas/IrEmitter'
     IrEmitterType:
       type: string
-      description: 'The type of the device, e.g. a Remote Two docking station, a network based IR blaster or something else.'
+      description: |
+        The type of the IR emitter device:
+        - `DOCK`: a Remote Two docking station
+        - `INTERNAL`: internal IR
+        - `IR_BLASTER`: a network based IR blaster
+        - `OTHER`: something else
       enum:
         - DOCK
+        - INTERNAL
         - IR_BLASTER
         - OTHER
     IrStatus:

--- a/core-api/rest/openapi.yaml
+++ b/core-api/rest/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Remote Two REST API
-  version: 0.28.4
+  version: 0.29.0
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
@@ -6230,6 +6230,57 @@ paths:
           $ref: '#/components/responses/Err401Unauthorized'
         '403':
           $ref: '#/components/responses/Err403Forbidden'
+  /cfg/features:
+    get:
+      tags:
+        - cfg
+      summary: Get feature flag settings.
+      description: |
+        Feature flag configuration.
+      operationId: getFeatureFlagSettings
+      parameters:
+        - name: default
+          in: query
+          description: Get default values instead of configured values.
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgFeatures'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
+    patch:
+      tags:
+        - cfg
+      summary: Modify a feature flag.
+      description: |
+        Enable or disable a feature flag setting.
+      operationId: updateFeatureFlagSetting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CfgFeatureUpdate'
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CfgFeatures'
+        '400':
+          $ref: '#/components/responses/Err400BadRequest'
+        '401':
+          $ref: '#/components/responses/Err401Unauthorized'
+        '403':
+          $ref: '#/components/responses/Err403Forbidden'
   /cfg/haptic:
     get:
       tags:
@@ -10068,6 +10119,8 @@ components:
           $ref: '#/components/schemas/CfgRemoteDevice'
         display:
           $ref: '#/components/schemas/CfgDisplay'
+        features:
+          $ref: '#/components/schemas/CfgFeatures'
         haptic:
           $ref: '#/components/schemas/CfgHaptic'
         localization:
@@ -10115,6 +10168,39 @@ components:
       required:
         - brightness
         - auto_brightness
+    CfgFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/CfgFeature'
+    CfgFeature:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+        title:
+          $ref: '#/components/schemas/LanguageText'
+        description:
+          $ref: '#/components/schemas/LanguageText'
+        help_url:
+          type: string
+          format: url
+      required:
+        - id
+        - enabled
+        - title
+        - description
+    CfgFeatureUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+      required:
+        - id
+        - enabled
     CfgHaptic:
       type: object
       properties:

--- a/core-api/websocket/asyncapi.yaml
+++ b/core-api/websocket/asyncapi.yaml
@@ -8,7 +8,7 @@ asyncapi: 2.2.0
 id: 'urn:com:unfoldedcircle:core'
 info:
   title: Remote Two WebSocket Core-API
-  version: '0.23.2-beta'
+  version: '0.24.0-beta'
   contact:
     name: API Support
     url: https://github.com/unfoldedcircle/core-api/issues
@@ -179,6 +179,8 @@ channels:
           - $ref: '#/components/messages/set_device_cfg'
           - $ref: '#/components/messages/get_display_cfg'
           - $ref: '#/components/messages/set_display_cfg'
+          - $ref: '#/components/messages/get_features_cfg'
+          - $ref: '#/components/messages/set_features_cfg'
           - $ref: '#/components/messages/get_haptic_cfg'
           - $ref: '#/components/messages/set_haptic_cfg'
           - $ref: '#/components/messages/get_localization_cfg'
@@ -868,6 +870,23 @@ components:
       summary: 🧪 Display settings response.
       payload:
         $ref: '#/components/schemas/displayCfgMsg'
+
+    get_features_cfg:
+      summary: 🧪 Get feature flag settings.
+      payload:
+        $ref: '#/components/schemas/getFeaturesCfgMsg'
+      x-response:
+        $ref: '#/components/messages/features_cfg'
+    set_features_cfg:
+      summary: 🧪 Modify a feature flag.
+      payload:
+        $ref: '#/components/schemas/setFeaturesCfgMsg'
+      x-response:
+        $ref: '#/components/messages/features_cfg'
+    features_cfg:
+      summary: 🧪 Feature flag settings response.
+      payload:
+        $ref: '#/components/schemas/featuresCfgMsg'
 
     get_haptic_cfg:
       summary: 🧪 Get haptic settings.
@@ -3449,6 +3468,44 @@ components:
               const: display_cfg
             msg_data:
               $ref: '#/components/schemas/cfgDisplay'
+          required:
+            - msg
+
+    getFeaturesCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: get_features_cfg
+            msg_data:
+              $ref: '#/components/schemas/getConfigurationOptions'
+          required:
+            - msg
+    setFeaturesCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonReq'
+        - properties:
+            msg:
+              type: string
+              const: set_features_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgFeatureUpdate'
+          required:
+            - msg
+            - msg_data
+    featuresCfgMsg:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/commonResp'
+        - properties:
+            msg:
+              type: string
+              const: features_cfg
+            msg_data:
+              $ref: '#/components/schemas/cfgFeatures'
           required:
             - msg
 
@@ -6962,6 +7019,8 @@ components:
           $ref: '#/components/schemas/cfgDevice'
         display:
           $ref: '#/components/schemas/cfgDisplay'
+        features:
+          $ref: '#/components/schemas/cfgFeatures'
         haptic:
           $ref: '#/components/schemas/cfgHaptic'
         localization:
@@ -7022,6 +7081,42 @@ components:
       required:
         - brightness
         - auto_brightness
+
+    cfgFeatures:
+      type: array
+      items:
+        $ref: '#/components/schemas/cfgFeature'
+
+    cfgFeature:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+        title:
+          $ref: '#/components/schemas/languageText'
+        description:
+          $ref: '#/components/schemas/languageText'
+        help_url:
+          type: string
+          format: url
+      required:
+        - id
+        - enabled
+        - title
+        - description
+
+    cfgFeatureUpdate:
+      type: object
+      properties:
+        id:
+          type: string
+        enabled:
+          type: boolean
+      required:
+        - id
+        - enabled
 
     cfgHaptic:
       type: object


### PR DESCRIPTION
### Added
- Core-API: feature flag settings.
- Initial internal IR emitter for web-configurator development. Disabled by default with feature flag `internal_ir`.
### Changed
- REST Core-API: enhance IrEmitterType enum with variant `INTERNAL`. This will be used for the internal IR blaster in the remote.
