### PR TITLE
Release v0.39.10-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
-### Added
-- REST Core-API: New option for switching activities: `run_off_sequence`.  
-  Run the original off-sequence of the old activity and dynamically filter out power-off commands.
-
 ---
+
+## v0.39.10-beta - 2024-01-14
+### Added
+- Activity groups: New option for switching activities: `run_off_sequence` ([#64](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/64)).  
+  Run the original off-sequence of the old activity and dynamically filter out power-off commands.
+- Web-configurator: configure, check and install remote software updates ([#274](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/274)).
+
+### Fixed
+- Web-configurator:
+  - Show correct dock brightness value ([#178](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/178)).
+  - Available entities not shown in last setup-flow step.
+  - Show busy indicators for backup & restore operations.
+- Integration drivers: `subscribe_events` message sequence after integration authentication ([#272](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/272)).
 
 ## v0.39.9-beta - 2024-01-10
 - Core-API: retrieve dock status and ethernet LED brightness settings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _Changes in the next release_
 
+### Added
+- REST Core-API: New option for switching activities: `run_off_sequence`.  
+  Run the original off-sequence of the old activity and dynamically filter out power-off commands.
+
 ---
 
 ## v0.39.9-beta - 2024-01-10

--- a/core-api/rest/openapi.yaml
+++ b/core-api/rest/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Remote Two REST API
-  version: 0.30.1
+  version: 0.30.2
   contact:
     name: API Support
     url: 'https://github.com/unfoldedcircle/core-api/issues'
@@ -9871,13 +9871,17 @@ components:
             - never
         turn_off_unused_entities:
           description: |
-            - `always`: Always turn off unused entities in the previous activity.
+            - `always`: Always turn off unused entities in the previous activity.  
+               All included entities are considered, not just the ones used in the on-sequence of the new activity.
             - `in_off_sequence`: Only turn off unused entities which are included in the off-sequence of the previous activity.
+            - `run_off_sequence`: Run the original off-sequence of the old activity and dynamically filter out power-off commands.  
+               All power-off commands from entities used in the new activity's power-on sequence will be filtered out.
             - `never`: Never turn off entities in the previous activity.
           type: string
           enum:
             - always
             - in_off_sequence
+            - run_off_sequence
             - never
     AdminPin:
       type: string


### PR DESCRIPTION
### Added
- Activity groups: New option for switching activities: `run_off_sequence` ([#64](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/64)).  
  Run the original off-sequence of the old activity and dynamically filter out power-off commands.
- Web-configurator: configure, check and install remote software updates ([#274](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/274)).

### Fixed
- Web-configurator:
  - Show correct dock brightness value ([#178](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/178)).
  - Available entities not shown in last setup-flow step.
  - Show busy indicators for backup & restore operations.
- Integration drivers: `subscribe_events` message sequence after integration authentication ([#272](https://github.com/unfoldedcircle/feature-and-bug-tracker/issues/272)).